### PR TITLE
Fix Safari bug, where broadcasting was not possible

### DIFF
--- a/backend/public/statics/files/broadcast.html
+++ b/backend/public/statics/files/broadcast.html
@@ -270,22 +270,22 @@
         //   url: 'stun:stun.gmx.net:3478'
         // },
         {
-          url: 'stun:stun.l.google.com:19302'
+          urls: ['stun:stun.l.google.com:19302']
         },
         {
-          url: 'stun:stun1.l.google.com:19302'
-        },
-        {
-
-          url: 'stun:stun2.l.google.com:19302'
+          urls: ['stun:stun1.l.google.com:19302']
         },
         {
 
-          url: 'stun:stun3.l.google.com:19302'
+          urls: ['stun:stun2.l.google.com:19302']
         },
         {
 
-          url: 'stun:stun4.l.google.com:19302'
+          urls: ['stun:stun3.l.google.com:19302']
+        },
+        {
+
+          urls: ['stun:stun4.l.google.com:19302']
         },
         /*
         {
@@ -327,22 +327,22 @@
         },
         */
         {
-          url: "turn:turn1.turn.group.video:3478",
+          urls: ["turn:turn1.turn.group.video:3478"],
           username: "turnuser",
           credential: "dJ4kP05PHcKN8Ubu",
         },
         {
-          url: "turn:turn2.turn.group.video:3478",
+          urls: ["turn:turn2.turn.group.video:3478"],
           username: "turnuser",
           credential: "XzfVP8cpNEy17hws",
         },
         {
-          url: "turns:turn1.turn.group.video:443",
+          urls: ["turns:turn1.turn.group.video:443"],
           username: "turnuser",
           credential: "dJ4kP05PHcKN8Ubu",
         },
         {
-          url: "turns:turn2.turn.group.video:443",
+          urls: ["turns:turn2.turn.group.video:443"],
           username: "turnuser",
           credential: "XzfVP8cpNEy17hws",
         },

--- a/backend/public/statics/files/index.html
+++ b/backend/public/statics/files/index.html
@@ -259,40 +259,40 @@
     var myPeerConnectionConfig = {
       iceServers: [
         {
-          url: 'stun:stun.l.google.com:19302'
+          urls: ['stun:stun.l.google.com:19302']
         },
         {
-          url: 'stun:stun1.l.google.com:19302'
-        },
-        {
-
-          url: 'stun:stun2.l.google.com:19302'
+          urls: ['stun:stun1.l.google.com:19302']
         },
         {
 
-          url: 'stun:stun3.l.google.com:19302'
+          urls: ['stun:stun2.l.google.com:19302']
         },
         {
 
-          url: 'stun:stun4.l.google.com:19302'
+          urls: ['stun:stun3.l.google.com:19302']
         },
         {
-          url: "turn:turn1.turn.group.video:3478",
+
+          urls: ['stun:stun4.l.google.com:19302']
+        },
+        {
+          urls: ["turn:turn1.turn.group.video:3478"],
           username: "turnuser",
           credential: "dJ4kP05PHcKN8Ubu",
         },
         {
-          url: "turn:turn2.turn.group.video:3478",
+          urls: ["turn:turn2.turn.group.video:3478"],
           username: "turnuser",
           credential: "XzfVP8cpNEy17hws",
         },
         {
-          url: "turns:turn1.turn.group.video:443",
+          urls: ["turns:turn1.turn.group.video:443"],
           username: "turnuser",
           credential: "dJ4kP05PHcKN8Ubu",
         },
         {
-          url: "turns:turn2.turn.group.video:443",
+          urls: ["turns:turn2.turn.group.video:443"],
           username: "turnuser",
           credential: "XzfVP8cpNEy17hws",
         },


### PR DESCRIPTION
Safari users were not able to broadcast their stream, which is a bug.

**This pull request introduces a fix to the bug.**

The reason being that the previous code was using the [deprecated `url` field](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer/url), for the [RTCIceServer](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer) object supplied to the configuration object to the [RTCPeerConnection constructor](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection).

Safari does not recognize the `url` field, and instead looks for a `urls` field. Because that field was absent, Safari threw a runtime exception, and refused to open any WebRTC connection, and thus no broadcasts were being made.