### PR TITLE
Change modal

### DIFF
--- a/backend/public/statics/files/v9/index.html
+++ b/backend/public/statics/files/v9/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Great Ape</title>
+    <title>LOGJAM</title>
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/graph.css">
     <link rel="icon" type="image/png" href="images/spark-logo.png">


### PR DESCRIPTION
So, in order for us to make the big move to Great Ape, we will need to remove as much branding of Group Video as much as possible.

Started off by removing the logo and the words "Group Video" in the name entry modal, as well as mentions of "SparkScience" in the title.

Initially attempted to use URL query params, but that failed, so settled with the simpler solution of simply deleting the title.