### PR TITLE
raise hand button UI issue > It's now getting removed after User clicks on it and Start Broadcasting #17

### DIFF
--- a/backend/public/statics/files/ga1/js/ui.js
+++ b/backend/public/statics/files/ga1/js/ui.js
@@ -281,6 +281,9 @@ async function onRaiseHand() {
         // video.srcObject = stream;
         document.getElementById("mic").style.display = "";
         document.getElementById("camera").style.display = "";
+
+        document.getElementById('raise_hand').remove();
+
     }
 }
 


### PR DESCRIPTION
@shovon 
.
.
Fixed the issue of the Hand Raise button not hiding when the user clicks on it.

Link to issue: https://github.com/sparkscience/not-greatape-frontend/issues/17
