### PR TITLE
Raise hand icon will be available after the audience clicks on it #17 

### DIFF
--- a/backend/public/statics/files/ga1/js/ui.js
+++ b/backend/public/statics/files/ga1/js/ui.js
@@ -293,7 +293,12 @@ function onLoad() {
 
 async function onRaiseHand() {
     const img = document.getElementById("raise_hand");
+
     if (img.dataset.status === "on") {
+
+        img.dataset.status = "off";
+        img.src = RAISE_HAND_OFF;
+
         if (sparkRTC.localStream) {
             // if (confirm(`Do you want to stop streaming?`)) {
             //     console.log('stopping...');
@@ -309,9 +314,6 @@ async function onRaiseHand() {
         // video.srcObject = stream;
         document.getElementById("mic").style.display = "";
         document.getElementById("camera").style.display = "";
-
-        document.getElementById('raise_hand').remove();
-
     }
 }
 


### PR DESCRIPTION
@shovon 
.
.
now raise the hand button will get disabled, when the audience starts broadcasting, and when the leading broadcaster gets rejoined, the audience side ui updates accordingly.

Linked Issue: https://github.com/sparkscience/not-greatape-frontend/issues/17
